### PR TITLE
Set config field when the type is a boolean.

### DIFF
--- a/conf/reflect.go
+++ b/conf/reflect.go
@@ -78,6 +78,9 @@ func recursivelySet(val reflect.Value, prefix string) error {
 			// you can only set with an int64 -> int
 			configVal := int64(viper.GetInt(tag))
 			thisField.SetInt(configVal)
+		case reflect.Bool:
+			configVal := viper.GetBool(tag)
+			thisField.SetBool(configVal)
 		case reflect.String:
 			configVal := viper.GetString(tag)
 			thisField.SetString(configVal)


### PR DESCRIPTION
It fixes an issue loading boolean values for fields like the automigrate setting.

Signed-off-by: David Calavera <david.calavera@gmail.com>