### PR TITLE
Split user.Data into app_metadata and user_metadata

### DIFF
--- a/api/token.go
+++ b/api/token.go
@@ -40,7 +40,7 @@ func (a *API) ResourceOwnerPasswordGrant(ctx context.Context, w http.ResponseWri
 	password := r.FormValue("password")
 
 	user := &models.User{}
-	if result := a.db.First(user, "email = ?", username); result.Error != nil {
+	if result := a.db.Preload("UserMetaData").Preload("AppMetaData").First(user, "email = ?", username); result.Error != nil {
 		if result.RecordNotFound() {
 			sendJSON(w, 400, &OAuthError{Error: "invalid_grant", Description: "No user found with this email"})
 		} else {
@@ -100,7 +100,7 @@ func (a *API) RefreshTokenGrant(ctx context.Context, w http.ResponseWriter, r *h
 	tx.Save(refreshToken)
 
 	user := &models.User{}
-	if result := tx.Model(refreshToken).Related(user); result.Error != nil {
+	if result := tx.Model(refreshToken).Preload("AppMetaData").Preload("UserMetaData").Related(user); result.Error != nil {
 		tx.Rollback()
 		if result.RecordNotFound() {
 			sendJSON(w, 400, &OAuthError{Error: "invalid_grant", Description: "Invalid Refresh Token"})
@@ -119,9 +119,8 @@ func (a *API) generateAccessToken(user *models.User) (string, error) {
 	token.Claims["id"] = user.ID
 	token.Claims["email"] = user.Email
 	token.Claims["exp"] = time.Now().Add(time.Second * time.Duration(a.config.JWT.Exp)).Unix()
-	for _, data := range user.Data {
-		token.Claims[data.Key] = data.Value()
-	}
+	token.Claims["app_metadata"] = user.AppMetaDataMap()
+	token.Claims["user_metadata"] = user.UserMetaDataMap()
 
 	return token.SignedString([]byte(a.config.JWT.Secret))
 }
@@ -133,9 +132,6 @@ func (a *API) issueRefreshToken(tx *gorm.DB, user *models.User, w http.ResponseW
 		InternalServerError(w, fmt.Sprintf("Error generating token: %v", err))
 		return
 	}
-
-	user.Data = []models.UserData{}
-	tx.Model(user).Related(&user.Data)
 
 	tokenString, err := a.generateAccessToken(user)
 

--- a/cmd/serve_cmd.go
+++ b/cmd/serve_cmd.go
@@ -24,6 +24,9 @@ func serve(config *conf.Configuration) {
 	if err != nil {
 		logrus.Fatalf("Error opening database: %+v", err)
 	}
+	defer db.Close()
+
+	db.LogMode(true)
 
 	mailer := mailer.NewMailer(config)
 	api := api.NewAPIWithVersion(config, db, mailer, Version)

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -90,6 +90,10 @@ func LoadConfig(cmd *cobra.Command) (*Configuration, error) {
 		config.JWT.AdminGroupName = "admin"
 	}
 
+	if config.JWT.Exp == 0 {
+		config.JWT.Exp = 3600
+	}
+
 	return config, nil
 }
 

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -14,8 +14,9 @@ import (
 // Configuration holds all the confiruation for netlify-auth
 type Configuration struct {
 	JWT struct {
-		Secret string `json:"secret"`
-		Exp    int    `json:"exp"`
+		Secret         string `json:"secret"`
+		Exp            int    `json:"exp"`
+		AdminGroupName string `json:"admin_group_name"`
 	} `json:"jwt"`
 	DB struct {
 		Driver      string `json:"driver"`
@@ -83,6 +84,10 @@ func LoadConfig(cmd *cobra.Command) (*Configuration, error) {
 
 	if err := configureLogging(config); err != nil {
 		return nil, err
+	}
+
+	if config.JWT.AdminGroupName == "" {
+		config.JWT.AdminGroupName = "admin"
 	}
 
 	return config, nil

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: c098b0bb5a12d25c55312600bf64f120ad7a1900461ac7f43019064923fe40f1
-updated: 2016-09-26T16:00:22.342761204-07:00
+hash: 9f813e1775bcf88725fa5efcd52588715a90ec2d45f5a2002cc35e1f912a6fc8
+updated: 2016-12-17T16:32:59.555594337-08:00
 imports:
 - name: github.com/dgrijalva/jwt-go
   version: 268038b363c7a8d7306b8e35bf77a1fde4b0c402
@@ -33,7 +33,7 @@ imports:
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/jinzhu/gorm
-  version: 5174cc5c242a728b435ea2be8a2f7f998e15429b
+  version: 0f2ceb5a775714a46bc344976324e3e439f8cdcc
   subpackages:
   - dialects/sqlite
 - name: github.com/jinzhu/inflection
@@ -65,8 +65,6 @@ imports:
 - name: github.com/rs/xhandler
   version: ed27b6fd65218132ee50cd95f38474a3d8a2cd12
 - name: github.com/Sirupsen/logrus
-  version: 3ec0642a7fb6488f65b06f9040adc67e3990296a
-- name: github.com/sirupsen/logrus
   version: 3ec0642a7fb6488f65b06f9040adc67e3990296a
 - name: github.com/spf13/afero
   version: 20500e2abd0d1f4564a499e83d11d6c73cd58c27

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,7 +5,7 @@ import:
 - package: github.com/guregu/kami
   version: v2.1
 - package: github.com/jinzhu/gorm
-  version: v1.0
+  version: 0f2ceb5a775714a46bc344976324e3e439f8cdcc
   subpackages:
   - dialects/sqlite
 - package: github.com/pborman/uuid
@@ -17,4 +17,4 @@ import:
   - bcrypt
 - package: gopkg.in/gomail.v2
   version: 2.0.0
-- package: github.com/sirupsen/logrus
+- package: github.com/Sirupsen/logrus


### PR DESCRIPTION
This follows the convention that Auth0 uses and separates custom data that the user can edit
from custom data that is relevant to the application layer and that users can't change themselves

Also introduces the concept of roles and currently has support for an 'admin' role.